### PR TITLE
fix potential stack crash in fill_counter()

### DIFF
--- a/lib/libpax/libpax_api.cpp
+++ b/lib/libpax/libpax_api.cpp
@@ -35,10 +35,10 @@ void (*report_callback)(void);
 struct count_payload_t* pCurrent_count;
 int counter_mode;
 
-void fill_counter(struct count_payload_t* count) {
-  count->wifi_count = libpax_wifi_counter_count();
-  count->ble_count = libpax_ble_counter_count();
-  count->pax = pCurrent_count->wifi_count + pCurrent_count->ble_count;
+void fill_counter(struct count_payload_t* pCount) {
+  pCount->wifi_count = libpax_wifi_counter_count();
+  pCount->ble_count = libpax_ble_counter_count();
+  pCount->pax = pCount->wifi_count + pCount->ble_count;
 }
 
 void libpax_counter_reset() {

--- a/lib/libpax/libpax_api.h
+++ b/lib/libpax/libpax_api.h
@@ -52,7 +52,7 @@ struct count_payload_t {
 /**
  *   Must be called before use of the lib. Initialze a callback the payload paxcount is written back too.
  *   @param[in] callback Callback which is called every pax_report_interval_sec to inform on current pax
- *   @param[out] memory location for pax count. Updated directly before callback is called
+ *   @param[out] current_count memory for pax count. Updated directly before callback is called
  *   @param[in] pax_report_interval_sec defines interval in s between a pax count callback.
  *   @param[in] countermode avalible modes TBD
 */


### PR DESCRIPTION
remove recursive reference to global variable `pCurrent_count` inside `fill_counter()`, when this function is called as `fill_counter(pCurrent_count)` from `report()`