### PR TITLE
don't count unrandomized ble macs & bugfix LSB ble mac

### DIFF
--- a/lib/libpax/blescan.cpp
+++ b/lib/libpax/blescan.cpp
@@ -179,8 +179,12 @@ void hci_evt_process(void *pvParameters) {
             rssi = -(0xFF - queue_data[data_ptr++]);
             if (ble_rssi_threshold && (rssi < ble_rssi_threshold))
               continue;  // do not count
-            else
+            else {
+              int universal_bit = (addr + 6 * i) & 0b10;
+              if(!universal_bit) 
+                continue;
               mac_add((uint8_t *)(addr + 6 * i), MAC_SNIFF_BLE);
+            }
           }
 
         // freeing all spaces allocated

--- a/lib/libpax/libpax.cpp
+++ b/lib/libpax/libpax.cpp
@@ -65,14 +65,9 @@ void reset_bucket() {
   seen_ids_count = 0;
 }
 
-int libpax_wifi_counter_count() {
-  return macs_wifi;
-}
+int libpax_wifi_counter_count() { return macs_wifi; }
 
-int libpax_ble_counter_count() {
-  return macs_ble;
-}
-
+int libpax_ble_counter_count() { return macs_ble; }
 
 int mac_add(uint8_t *paddr, snifftype_t sniff_type) {
   uint16_t *id;
@@ -81,6 +76,9 @@ int mac_add(uint8_t *paddr, snifftype_t sniff_type) {
     
   //ESP_LOGD(TAG, "MAC=%02x:%02x:%02x:%02x:%02x:%02x -> ID=%04x", paddr[0],
   //         paddr[1], paddr[2], paddr[3], paddr[4], paddr[5], *id);
+    
+  // if it is NOT a locally administered ("random") mac, we don't count it
+  if (!(paddr[0] & 0b10)) return false;
   
   int added = add_to_bucket(*id);
 

--- a/lib/libpax/wifiscan.cpp
+++ b/lib/libpax/wifiscan.cpp
@@ -58,17 +58,9 @@ wifi_sniffer_packet_handler(void* buff, wifi_promiscuous_pkt_type_t type) {
 
   if ((wifi_rssi_threshold) &&
       (ppkt->rx_ctrl.rssi < wifi_rssi_threshold))  // rssi is negative value
-  {
-    return;
-  }
-
-  int universal_bit = hdr->addr2[0] & 0b10;
-
-  if(!universal_bit) {
      return;
-  }
-
-  mac_add((uint8_t *)hdr->addr2, MAC_SNIFF_WIFI);
+  else 
+     mac_add((uint8_t *)hdr->addr2, MAC_SNIFF_WIFI);
 }
 
 uint16_t channels_map;


### PR DESCRIPTION
1) Checking universal bit is now happening centralized in mac_add(), thus working for wifi and ble macs in same manner. Bugfix: Before ble macs where not checked for universal bit.

2) Bugfix: BLE macs appear in little endian format, thus LSB processing is required. But they were processed as MSB. Which means that all octets of ble macs were swapped.