### PR TITLE
Added initial zeroing of memory when serializing config

### DIFF
--- a/lib/libpax/libpax_api.cpp
+++ b/lib/libpax/libpax_api.cpp
@@ -52,6 +52,7 @@ void report(TimerHandle_t xTimer) {
 void libpax_serialize_config(char* store_addr,
                              struct libpax_config_t* configuration) {
   struct libpax_config_storage_t storage_buffer;
+  memset(&storage_buffer, 0, sizeof(struct libpax_config_storage_t));
   storage_buffer.major_version = CONFIG_MAJOR_VERSION;
   storage_buffer.minor_version = CONFIG_MINOR_VERSION;
   memcpy(&(storage_buffer.config), configuration,

--- a/test/libpax_test_cases.cpp
+++ b/test/libpax_test_cases.cpp
@@ -96,7 +96,18 @@ void test_config_store() {
                                   sizeof(struct libpax_config_t)));
   struct libpax_config_t read_configuration;
   char configuration_memory[LIBPAX_CONFIG_SIZE];
+  
+  // Test if memory for two serialize runs is the same
+  char configuration_memory_second_run[LIBPAX_CONFIG_SIZE];
   libpax_serialize_config(configuration_memory, &current_config);
+  libpax_serialize_config(configuration_memory_second_run, &current_config);
+  TEST_ASSERT_EQUAL(0, memcmp(configuration_memory, configuration_memory_second_run, LIBPAX_CONFIG_SIZE));
+
+  // Test if memory in spare area is zeroed
+  uint8_t spare_cmp[23];
+  memset(spare_cmp, 0, sizeof(spare_cmp));
+  TEST_ASSERT_EQUAL(0, memcmp(((libpax_config_storage_t*)configuration_memory)->pad, spare_cmp, sizeof(spare_cmp)));
+
   TEST_ASSERT_EQUAL(
       0, libpax_deserialize_config(configuration_memory, &read_configuration));
   TEST_ASSERT_EQUAL(0, memcmp(&current_config, &read_configuration,


### PR DESCRIPTION
While using the configuration store we noticed that some area in the struct kept being random when serializing.
To fix this we added some zeroing of the structs' memory before copying the config struct areas into it.