### PR TITLE
Add needed dependency in cmake file for idf building

### DIFF
--- a/lib/libpax/CMakeLists.txt
+++ b/lib/libpax/CMakeLists.txt
@@ -1,6 +1,8 @@
 # This file was automatically generated for projects
 # without default 'CMakeLists.txt' file.
 
-FILE(GLOB_RECURSE app_sources ${CMAKE_SOURCE_DIR}/src/*.*)
+FILE(GLOB_RECURSE app_sources *.*)
 
-idf_component_register(SRCS ${app_sources})
+idf_component_register(SRCS ${app_sources}
+    INCLUDE_DIRS .
+    REQUIRES nvs_flash bt spi_flash)


### PR DESCRIPTION
While developing with libpax we noticed that using the idf build chain it fails to include the component. 
So we adjusted the cmake configuration as in this pull request.

This should not affect platformio building and including.