### PR TITLE
Fix crash when calling start twice in a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Protect start function from being executed when libpax is already started
 
 ## [1.1.0] - 2022-10-29
 - Adapt Wifi country settings to ESP IDF v4.4 Wi-Fi API


### PR DESCRIPTION
calling `libpax_counter_start` twice in a row results in a crash. The code is not thread-safe so it might still be possible to trigger a crash when calling start in prallel in two thread at the exact same time.

TBD should libpax be thread-safe? Other parts of the API also don't care about thread-safety.