### PR TITLE
fix: off-by-one error

### DIFF
--- a/lib/libpax/libpax.cpp
+++ b/lib/libpax/libpax.cpp
@@ -24,7 +24,9 @@ enum { BITS_PER_WORD = sizeof(bitmap_t) * CHAR_BIT };
 #define WORD_OFFSET(b) ((b) / BITS_PER_WORD)
 #define BIT_OFFSET(b) ((b) % BITS_PER_WORD)
 
-DRAM_ATTR bitmap_t seen_ids_map[0x07FF]; // full enumeration of uint16_t
+// The bitmap requires 2**16 = 65536 entries,
+// while using 32 bit integers, we need 65536 / 32 = 2048 integers
+DRAM_ATTR bitmap_t seen_ids_map[2048];
 int seen_ids_count = 0;
 
 uint16_t macs_wifi = 0;


### PR DESCRIPTION
I believe https://github.com/dbinfrago/libpax/pull/33 introduces a serious bug by shrinking the array size by one too much. This can lead to accessing - and writing! - to the wrong memory.

Changes:

- off-by-one-error: 0x07FF is 2047 we require 2048 entries.
- readability: explain magic number in code comment